### PR TITLE
Rework clean functionality for removing deployed assets

### DIFF
--- a/controller/custom/deploy_asset.js
+++ b/controller/custom/deploy_asset.js
@@ -10,6 +10,8 @@ const chalk = require('chalk');
 
 const workspace_utilities = require('open_bilrost/assetmanager/workspace_utilities')(path => Path.join('.bilrost', path ? path : '/'));
 
+const deploy_log = require('./deploy_log');
+
 // TODO replace all controllers to models
 const vcs = require('../vcs');
 const am = require('../am');
@@ -20,44 +22,29 @@ const am_model = require('../../model/am')(am_config);
 const log = require('../../util/log');
 const ifs = require('../../util/ifs');
 const elapsed_time = require('../../util/elapsed_time');
-const file_uri = require('../../util/file_uri');
+const file_url = require('../../util/file_uri');
 
 const generate_random_name = () => crypto.randomBytes(6).toString('hex');
 
 const map_definition_to_create_origin_inputs = (def, deploy_tmp_directory, cwd) => {
-    return def.origins.map(origin => {
+    return def.origins.map(({ deploys, workspace, organization, project_name, branch }) => {
         const name = generate_random_name();
-        const path = origin.workspace ? Path.join(cwd, origin.workspace) : Path.join(deploy_tmp_directory, name);
-        const url = file_uri(path);
+        const is_workspace = workspace !== undefined;
+        const workspace_path = is_workspace ? Path.join(cwd, workspace) : Path.join(deploy_tmp_directory, name);
+        const file_uri = file_url(workspace_path);
         const description = name + " deployment workspace";
         return {
-            file_uri: url,
-            workspace_path: path,
+            is_workspace,
             name,
-            organization: origin.organization,
-            project_name: origin.project_name,
-            branch: origin.branch,
+            file_uri,
+            workspace_path,
+            organization,
+            project_name,
+            branch,
             description,
-            deploys: origin.deploys,
-            workspace: origin.workspace
+            deploys
         };
     });
-};
-
-const ignored_files_when_moving = ['.git', '.svn', '.gitignore', '.bilrost'];
-
-const ifs_service = {
-    copy (resources, cwd, origin_base_path, origin_name, dest_base_relative_path, dest_relative_path) {
-        const origin_path = Path.join(origin_base_path, origin_name).replace(/\\/g, '/');
-        const dest_path = Path.join(cwd, dest_relative_path ? dest_relative_path :  "").replace(/\\/g, '/');
-        return ifs.copyContent(resources, origin_path, dest_path, dest_base_relative_path, ignored_files_when_moving);
-    },
-
-    link (resources, cwd, origin_base_path, origin_name, dest_base_relative_path, dest_relative_path) {
-        const origin_path = Path.join(origin_base_path, origin_name).replace(/\\/g, '/');
-        const dest_path = Path.join(cwd, dest_relative_path ? dest_relative_path :  "").replace(/\\/g, '/');
-        return ifs.createLink(resources, origin_path, dest_path, dest_base_relative_path, ignored_files_when_moving);
-    }
 };
 
 const start_timer = () => {
@@ -85,65 +72,101 @@ const pass_enoent_error = err => {
     }
 };
 
-/*const clean_installed_assets = (deploy_file_name, cwd, deploy_tmp_directory) => {
-    return ifs.readJson(Path.join(cwd, deploy_file_name))
-        .then(def => map_definition_to_create_origin_inputs(def, deploy_tmp_directory, cwd)
-            .reduce((origin_sequence, origin) => origin_sequence
-                .then(() => clean(origin, cwd)),
-            Promise.resolve()))
-        .then(() => {
-            console.info(chalk.green('Cleaning done'));
-        });
-};*/
+const remove_all_empty_directories = resource_relative_path => {
+    const remove_if_not_empty = path => ifs.readdir(path)
+        .then(files => {
+            if (!files.length) {
+                return ifs.remove(path);
+            }
+        })
+        .catch(err => err && err.code === 1 ? Promise.resolve() : Promise.reject(err));
+    const create_removal_promise = path => () => remove_if_not_empty(path);
+    const removal_promises = [];
+    while (resource_relative_path.split('/').length > 1) {
+        removal_promises.push(create_removal_promise(resource_relative_path));
+        resource_relative_path = resource_relative_path
+            .split('/')
+            .filter((basename, index, array) => index !== array.length - (basename === '' ? 2 : 1))
+            .join('/');
+    }
+    removal_promises.push(create_removal_promise(resource_relative_path));
+    return removal_promises.reduce((sequence, promise) => sequence.then(promise), Promise.resolve());
+};
 
-const install_assets = (deploy_file_name, cwd, deploy_tmp_directory, is_copy) => {
+const clean = cwd => deploy_log.list_resources(cwd)
+    .then(resources => Promise.all(resources.map(relative_path => {
+        const absolute_path = Path.join(cwd, relative_path);
+        return ifs.remove(absolute_path)
+            .then(() => remove_all_empty_directories(relative_path));
+    })))
+    .then(() => deploy_log.del(cwd))
+    .then(() => remove_all_empty_directories(deploy_log.FOLDER_NAME));
+
+const install = (deploy_file_name, cwd, deploy_tmp_directory, is_copy) => {
     let sub_id = '';
     const get_time = start_timer();
 
-    const install_from_project = origin => origin.deploys.reduce((deploy_sequence, deploy) => deploy_sequence
-        .then(() => vcs.subscribe(origin.file_uri, 'ASSET', deploy.ref))
+    const copy_or_link_content = (resources, workspace_path, base, dest) => Promise.all(resources.map(resource_absolute_path => {
+        const origin_absolute_path_with_base = Path.join(workspace_path, base);
+        const dest_absolute_path_without_base = Path.join(cwd, dest);
+        const dest_absolute_path_with_base = Path.join(dest_absolute_path_without_base, Path.relative(origin_absolute_path_with_base, resource_absolute_path));
+        return ifs[is_copy ? 'copy' : 'link'](resource_absolute_path, dest_absolute_path_with_base)
+            .then(() => dest_absolute_path_with_base);
+    }));
+
+    const update_log = resources => deploy_log.update(cwd, resources.map(absolute_path => ({ path: Path.relative(cwd, absolute_path) })));
+
+    const install_from_project = origin => origin.deploys.reduce((deploy_sequence, { ref, base = './', dest = './'}) => deploy_sequence
+        .then(() => vcs.subscribe(origin.file_uri, 'ASSET', ref))
         .then(sub => {
             sub_id = sub.body.id;
-            console.info(chalk.green(`${get_time()}: Checked out ${deploy.ref} asset`));
+            console.info(chalk.green(`${get_time()}: Checked out ${ref} asset`));
         })
-        .then(() => get_asset_resources(origin.file_uri, deploy.ref, origin.workspace_path))
-        .then(resources => ifs_service[is_copy ? 'copy' : 'link'](resources, cwd, deploy_tmp_directory, origin.name, deploy.base, deploy.dest))
+        .then(() => get_asset_resources(origin.file_uri, ref, origin.workspace_path))
+        .then(resources => copy_or_link_content(resources, origin.workspace_path, base, dest))
+        .then(update_log)
         .then(() => vcs.unsubscribe(origin.file_uri, sub_id))
         .then(() => {
-            console.info(chalk.green(`${get_time()}: Installed ${deploy.ref} asset content to ${deploy.dest ? deploy.dest : './'}`));
+            console.info(chalk.green(`${get_time()}: Installed ${ref} asset content to ${dest}`));
         }),
     Promise.resolve());
 
-    const install_from_workspace = origin => origin.deploys.reduce((deploy_sequence, deploy) => deploy_sequence
-        .then(() => vcs.subscribe(origin.file_uri, 'ASSET', deploy.ref))
-        .then(() => get_asset_resources(origin.file_uri, deploy.ref, origin.workspace_path))
-        .then(resources => ifs_service[is_copy ? 'copy' : 'link'](resources, cwd, Path.join(cwd, origin.workspace), '', deploy.base, deploy.dest))
+    const install_from_workspace = origin => origin.deploys.reduce((deploy_sequence, { workspace_path, ref, base = './' , dest = './' }) => deploy_sequence
+        .then(() => vcs.subscribe(origin.file_uri, 'ASSET', ref))
+        .then(() => get_asset_resources(origin.file_uri, ref, origin.workspace_path))
+        .then(resources => copy_or_link_content(resources, origin.workspace_path, base, dest))
+        .then(update_log)
         .then(() => {
-            console.info(chalk.green(`${get_time()}: Installed ${deploy.ref} asset content to ${deploy.dest ? deploy.dest : './'}`));
+            console.info(chalk.green(`${get_time()}: Installed ${ref} asset content to ${dest}`));
         }),
     Promise.resolve());
 
-    const init = origin => origin.workspace ? am_model.populate_workspace(origin)
+    const init_assets = origin => origin.is_workspace ? am_model.populate_workspace(origin)
         .catch(res => {
             if (res.statusCode !== 403) {
-                throw res.body;
+                throw res;
             }
         })
         .then(() => am_model.add_workspace_to_favorite(origin.file_uri))
         .catch(res => {
             if (res.statusCode !== 403) {
-                throw res.body;
+                throw res;
             }
         }) : am.create_workspace(origin);
 
+    const init_deploy = () => deploy_log.access(cwd)
+        .then(() => clean(cwd), pass_enoent_error)
+        .then(() => deploy_log.create(cwd, deploy_log.format()));
+
     return ifs.mkdirs(deploy_tmp_directory)
         .catch(pass_enoent_error)
+        .then(() => init_deploy())
         .then(() => ifs.readJson(Path.join(cwd, deploy_file_name)))
         .then(def => map_definition_to_create_origin_inputs(def, deploy_tmp_directory, cwd)
             .reduce((origin_sequence, origin) => origin_sequence
-                .then(() => init(origin))
-                .then(() => origin.workspace ? install_from_workspace(origin) : install_from_project(origin))
-                .then(() => origin.workspace ? Promise.resolve() : am.delete_workspace(origin.file_uri)),
+                .then(() => init_assets(origin))
+                .then(() => origin.is_workspace ? install_from_workspace(origin) : install_from_project(origin))
+                .then(() => origin.is_workspace ? Promise.resolve() : am.delete_workspace(origin.file_uri)),
             Promise.resolve()))
         .then(() => {
             console.info(chalk.green(`Deployment done within ${get_time()}`));
@@ -152,6 +175,6 @@ const install_assets = (deploy_file_name, cwd, deploy_tmp_directory, is_copy) =>
 };
 
 module.exports = {
-    install_assets/*,
-    clean_installed_assets*/
+    install,
+    clean
 };

--- a/controller/custom/deploy_log.js
+++ b/controller/custom/deploy_log.js
@@ -6,13 +6,13 @@
 
 'use strict';
 
-const walkback = require('walk-back');
 const Path = require('path');
 
 const ifs = require('../../util/ifs');
 
 const VERSION = '1.0.0';
 const NOT_FOUND_ERROR_MESSAGE = 'deploy log not found!';
+const FOLDER_NAME = '.bilrost';
 const FILE_NAME = 'deployed.json';
 
 const format = () => ({
@@ -21,23 +21,22 @@ const format = () => ({
     resources: []
 });
 
-const create = (base_path, log) => ifs.outputJson(Path.join(base_path, FILE_NAME), log);
+const stringify = log => JSON.stringify(log, null, 4);
+
+const create = (base_path, log) => ifs.outputFile(Path.join(base_path, FOLDER_NAME, FILE_NAME), stringify(log));
+
+const access = (base_path, log) => ifs.access(Path.join(base_path, FOLDER_NAME, FILE_NAME), log);
 
 const read = base_path => {
-    const internal_path = walkback(base_path, '.bilrost');
-    if (internal_path) {
-        const deploy_log_path = Path.join(internal_path, FILE_NAME);
-        return ifs.readJson(deploy_log_path)
-            .catch(err => {
-                if (err.includes('ENOENT')) {
-                    throw new Error(NOT_FOUND_ERROR_MESSAGE);
-                } else {
-                    throw err;
-                }
-            });
-    } else {
-        return Promise.reject(new Error(NOT_FOUND_ERROR_MESSAGE));
-    }
+    const deploy_log_path = Path.join(base_path, FOLDER_NAME, FILE_NAME);
+    return ifs.readJson(deploy_log_path)
+        .catch(err => {
+            if (err.toString().includes('ENOENT')) {
+                throw new Error(NOT_FOUND_ERROR_MESSAGE);
+            } else {
+                throw err;
+            }
+        });
 };
 
 const update = (base_path, resources) => read(base_path)
@@ -49,18 +48,21 @@ const update = (base_path, resources) => read(base_path)
         }
     })
     .then(deploy_log => {
-        deploy_log.resources.concat(resources);
+        deploy_log.resources = deploy_log.resources.concat(resources);
         return create(base_path, deploy_log)
             .then(() => deploy_log);
     });
 
-const del = base_path => ifs.remove(Path.join(base_path, FILE_NAME));
+const del = base_path => ifs.remove(Path.join(base_path, FOLDER_NAME, FILE_NAME));
 
 const list_resources = base_path => read(base_path)
     .then(deploy_log => deploy_log.resources.map(resource => resource.path));
 
 module.exports = {
+    FOLDER_NAME,
     FILE_NAME,
+    stringify,
+    access,
     create,
     read,
     update,

--- a/deploy_cli.js
+++ b/deploy_cli.js
@@ -37,10 +37,22 @@ program
     .description('Install asset')
     .option('-c, --copy', 'copy content')
     .action(options => {
-        bilrost_starter.start_if_not_running(9224, () => deploy_actions.install_assets('bilrost.json', process.cwd().replace(/\\/g, '/'), deploy_path, options.copy), program.bilrostOutput)
+        bilrost_starter.start_if_not_running(9224, () => deploy_actions.install('bilrost.json', process.cwd(), deploy_path, options.copy), program.bilrostOutput)
             .catch(err => {
                 log.spawn_error(err);
                 process.exit();
+            });
+    });
+
+program
+    .command('clean')
+    .description('Clean previously installed assets')
+    .action(options => {
+        bilrost_starter.start_if_not_running(9224, () => deploy_actions.clean(process.cwd()), program.bilrostOutput)
+            .catch(err => {
+                log.spawn_error(err);
+                process.exit();
+
             });
     });
 
@@ -55,18 +67,6 @@ program
             .catch(err => {
                 log.spawn_error(err);
                 process.exit();
-            });
-    });
-
-program
-    .command('clean')
-    .description('Clean previously installed assets')
-    .action(options => {
-        bilrost_starter.start_if_not_running(9224, () => deploy_actions.clean_installed_assets('bilrost.json', process.cwd().replace(/\\/g, '/'), deploy_path), program.bilrostOutput)
-            .catch(err => {
-                log.spawn_error(err);
-                process.exit();
-
             });
     });
 

--- a/examples/bilrost.json
+++ b/examples/bilrost.json
@@ -6,19 +6,19 @@
             "deploys": [
                 {
                     "ref": "/assets/test_1_1_0.level",
-                    "dest": "./example_project/Assets/" 
+                    "dest": "./example_workspace/Assets/" 
                 },
                 {
                     "ref": "/assets/prefab/mall.prefab",
-                    "dest": "./example_project/Assets/" 
+                    "dest": "./example_workspace/Assets/" 
                 },
                 {
                     "ref": "/assets/prefab/test_1_1_0.prefab",
-                    "dest": "./example_project/Assets/" 
+                    "dest": "./example_workspace/Assets/" 
                 },
                 {
                     "ref": "/assets/levels/test_001.level",
-                    "dest": "./example_project/Assets/" 
+                    "dest": "./example_workspace/Assets/" 
                 }
             ]
         },

--- a/model/am.js
+++ b/model/am.js
@@ -33,7 +33,7 @@ module.exports = config => {
         '/assetmanager/workspaces/' + encodeURIComponent(identifier) + '/favorites'
     ).then(body => {
         if (body === 'Ok') {
-            return { message: 'Successfully forgot' };
+            return { message: 'Successfully forgotten' };
         } else {
             throw {
                 message: 'Unexpected body answer',
@@ -47,7 +47,7 @@ module.exports = config => {
         '/assetmanager/workspaces/favorites/reset'
     ).then(body => {
         if (body === 'Ok') {
-            return { message: 'Successfully forgot' };
+            return { message: 'Successfully forgotten' };
         } else {
             throw {
                 message: 'Unexpected body answer',

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha --recursive --grep DO_NOT_RUN --invert --exit",
-    "jshint": "./node_modules/.bin/jshint . --exit --exclude node_modules"
+    "jshint": "./node_modules/.bin/jshint . --exclude node_modules"
   }
 }

--- a/test/am.js
+++ b/test/am.js
@@ -54,7 +54,7 @@ describe('Am model', function () {
         am.forget_workspace_in_favorite('test')
             .then(output => {
                 should.deepEqual({
-                    message: 'Successfully forgot'
+                    message: 'Successfully forgotten'
                 }, output);
                 stub.restore_request('delete');
                 done();

--- a/test/deploy_log.js
+++ b/test/deploy_log.js
@@ -10,8 +10,8 @@ const fs = require('fs-extra');
 
 const deploy_log = require('../controller/custom/deploy_log');
 
-const base_path = 'tmp/.bilrost';
-const deploy_log_path = Path.join(base_path, deploy_log.FILE_NAME);
+const base_path = 'tmp';
+const deploy_log_path = Path.join(base_path, deploy_log.FOLDER_NAME, deploy_log.FILE_NAME);
 
 const log = deploy_log.format();
 log.resources = [
@@ -28,7 +28,7 @@ describe('deploy log', function () {
     before(function (done) {
         deploy_log.create(base_path, log)
             .then(() => {
-                should.equal(fs.readFileSync(deploy_log_path).toString(), JSON.stringify(log) + '\n');
+                should.equal(fs.readFileSync(deploy_log_path).toString(), deploy_log.stringify(log));
                 done();
             })
             .catch(done);
@@ -93,11 +93,11 @@ describe('deploy log', function () {
                 path: 'foo/bar'
             }
         ];
-        log.resources.concat(resources_to_push);
-        deploy_log.update('tmp')
-            .then(deploy_log => {
-                should.deepEqual(deploy_log.resources, log.resources);
-                should.equal(fs.readFileSync(deploy_log_path).toString(), JSON.stringify(log) + '\n');
+        log.resources = log.resources.concat(resources_to_push);
+        deploy_log.update('tmp', resources_to_push)
+            .then(res_log => {
+                should.deepEqual(res_log.resources, log.resources);
+                should.equal(fs.readFileSync(deploy_log_path).toString(), deploy_log.stringify(log));
                 done();
             })
             .catch(done);

--- a/use_case_deploy.bat
+++ b/use_case_deploy.bat
@@ -12,10 +12,9 @@ call git submodule add --force -b production_repo git@github.com:fl4re/open_bilr
 echo "Dave deploys assets from workspace with 'copy' option"
 call bilrost-deploy install --copy -B
 
-echo "Dave removes deployed files"
+echo "Dave cleans deployed files"
+call bilrost-deploy clean
 
-rm -rf example_workspace
-rm -rf example_project
 echo %WORKSPACE_FILE_URI%
 call bilrost delete-workspace %WORKSPACE_FILE_URI%
 

--- a/use_case_deploy.sh
+++ b/use_case_deploy.sh
@@ -14,8 +14,7 @@ bilrost-deploy install --copy -B
 
 echo "Dave removes deployed files"
 
-rm -rf example_workspace
-rm -rf example_project
+bilrost-deploy clean
 bilrost delete-workspace %WORKSPACE_FILE_URI%
 
 cd ..

--- a/util/ifs.js
+++ b/util/ifs.js
@@ -30,18 +30,16 @@ const createReadStream = path => fs.createReadStream(path);
 
 const outputJson = (path, content) => promisify(fs.outputJson)(path, content);
 
+const outputFile = (path, content) => promisify(fs.outputFile)(path, content);
+
 const is_directory_sync = path => {
     const stats = fs.lstatSync(path);
     return stats.isDirectory();
 };
 
-const copyContent = (resources, origin, target, base, ignore) => resources.reduce((copy_sequence, file) => copy_sequence
-    .then(() => promisify(fs.copy)(file, path.join(target, path.relative(path.join(origin, base ? base : ""), file)))),
-Promise.resolve());
+const copy = (origin, dest) => promisify(fs.copy)(origin, dest);
 
-const createLink = (resources, origin, target, base, ignore) => resources.reduce((copy_sequence, file) => copy_sequence
-    .then(() => promisify(fs.ensureSymlink)(file, path.join(target, path.relative(path.join(origin, base ? base : ""), file)))),
-Promise.resolve());
+const link = (origin, dest) => promisify(fs.ensureSymlink)(origin, dest);
 
 module.exports = {
     get_files_recursively,
@@ -51,8 +49,9 @@ module.exports = {
     readJson,
     mkdirs,
     remove,
-    copyContent,
+    copy,
     outputJson,
+    outputFile,
     is_directory_sync,
-    createLink
+    link
 };


### PR DESCRIPTION
- Reworked clean accessible from `bilrost-deploy clean`.

From this PR, deploy happens as following:

1. User starts installation with `bilrost-deploy install`
1. Is deploy log accessible within `.bilrost/deployed.json` (relative from where the cli command has been input)? Go to step 4 if not.
2. Read logs and remove all listed resources.
3. Remove log. 
4. Create empty log.
5. Update log for each deployed asset and insert dependent resources.
1. Deployment ends.
