### PR TITLE
Silent error if workspace is not found when resetting

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -179,13 +179,20 @@ program
     .command('reset-workspace [workspace_relative_path]')
     .description('Reset a workpsace')
     .option('-f, --force', 'force reset without prompt')
-    .action(start_bilrost_if_not_running((workspace_relative_path, options) => options.force ? am_actions.reset_workspace(Path.join(program.pwd, workspace_relative_path ? workspace_relative_path : '')) : _prompt(are_you_sure)
-        .then(answer => {
-                if (answer.are_you_sure === 'y') {
-                    return am_actions.reset_workspace(Path.join(program.pwd, workspace_relative_path ? workspace_relative_path : ''));
-                }
-        })
-    ))
+    .option('-s, --silent', 'silent error output if workspace not found or invalid')
+    .action(start_bilrost_if_not_running((workspace_relative_path, options) => {
+        const workspace_absolute_path = Path.join(program.pwd, workspace_relative_path ? workspace_relative_path : '');
+        if (options.force) {
+            return am_actions.reset_workspace(workspace_absolute_path, options.silent);
+        } else {
+            return _prompt(are_you_sure)
+                .then(answer => {
+                    if (answer.are_you_sure === 'y') {
+                        return am_actions.reset_workspace(workspace_absolute_path, options.silent);
+                    }
+                });
+        }
+    }))
     .on('--help', () => {
         console.log();
         console.log('  WARNING');

--- a/controller/am.js
+++ b/controller/am.js
@@ -38,9 +38,14 @@ const create_workspace = input => {
         .catch(log.spawn_error);
 };
 
-const reset_workspace = path => am_models.reset_workspace(file_uri(path))
+const reset_workspace = (path, silent) => am_models.reset_workspace(file_uri(path))
     .then(log.spawn_success)
-    .catch(log.spawn_error);
+    .catch(err => {
+        const is_filtered_error = silent && err.statusCode === 400;
+        if (!is_filtered_error) {
+            log.spawn_error(err);
+        }
+    });
 
 const populate_workspace = input => {
     input.file_uri = input.path ? file_uri(input.path) : input.file_uri;


### PR DESCRIPTION
This will avoid to output an error if there is an attempt to reset a workspace that has not been populated yet