### PR TITLE
Remove workspace with relative

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -60,9 +60,9 @@ function help() {
     program.help();
 }
 
-const find_workspace_url = () => {
+const find_workspace_url = (pwd = program.pwd) => {
     try {
-        return workspace_finder(program.pwd);
+        return workspace_finder(pwd);
     } catch(err) {
         logger.spawn_error(err.toString());
         throw err;
@@ -203,15 +203,23 @@ program
     });
 
 program
-    .command('delete-workspace <identifier>')
+    .command('delete-workspace <relative_path>')
     .description('Delete a workspace')
-    .action(start_bilrost_if_not_running(am_actions.delete_workspace))
+    .option('-i, --identifier <identifier>', 'workspace identifier')
+    .action(start_bilrost_if_not_running((workspace_relative_path, options) => {
+        const workspace_absolute_path = Path.join(program.pwd, workspace_relative_path ? workspace_relative_path : '');
+        const identifier = options.identifier || find_workspace_url(workspace_absolute_path);
+        return am_actions.delete_workspace(identifier);
+    }))
     .on('--help', () => {
         console.log();
         console.log('  Additional information:');
         console.log();
-        console.log('  Given identifier can be a workspace name or file uri');
+        console.log('  This is not possible to remove workspace if terminal\'s current working directory is root or child of workspace location.');
+        console.log();
+        console.log('  Given optional identifier can be a workspace name or file uri');
         console.log('  Run "bilrost list-workspaces" to get these identifiers');
+
     });
 
 program.command(' -- ');

--- a/use_case_deploy.bat
+++ b/use_case_deploy.bat
@@ -1,8 +1,5 @@
 rem Copyright (C) 2015-2018 Starbreeze AB All Rights Reserved.
 
-set DIR_PATH=%CD:\=/%
-set WORKSPACE_FILE_URI=file:///%DIR_PATH%/examples/open_bilrost_test_project
-
 cd examples
 
 echo "Dave initializes a submodule of a bilrost project, its relative path mirrors the one informed to deployment file"
@@ -15,7 +12,6 @@ call bilrost-deploy install --copy -B
 echo "Dave cleans deployed files"
 call bilrost-deploy clean
 
-echo %WORKSPACE_FILE_URI%
-call bilrost delete-workspace %WORKSPACE_FILE_URI%
+call bilrost delete-workspace open_bilrost_test_project
 
 cd ..

--- a/use_case_deploy.sh
+++ b/use_case_deploy.sh
@@ -15,6 +15,6 @@ bilrost-deploy install --copy -B
 echo "Dave removes deployed files"
 
 bilrost-deploy clean
-bilrost delete-workspace %WORKSPACE_FILE_URI%
+bilrost delete-workspace open_bilrost_test_project
 
 cd ..


### PR DESCRIPTION
Here is the new command for removing a workspace:

```
  Usage: delete-workspace [options] <relative_path>

  Delete a workspace

  Options:

    -i, --identifier <identifier>  workspace identifier
    -h, --help                     output usage information


  Additional information:

  This is not possible to remove workspace if terminal's current 
  working directory is root or child of workspace location.

  Given optional identifier can be a workspace name or file uri
  Run "bilrost list-workspaces" to get these identifiers
```