### PR TITLE
Create workspace required arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Bilrost comes with a command line tool to interact with the version control syst
 
 1/ Create workspace.
 
-A workspace is the local representation of a project. This is where assets are updated.
+A workspace is the local representation of a project mapped from a github repository. This is where assets are updated.
 
-`bilrost create-workspace test-workspace relative/path/to/folder --organization org_name --project-name test --branch master --description "test workspace"`
+`bilrost create-workspace relative/path/to/folder/to/create organization test master --description "test workspace"`
 
 2/ Create branch.
 

--- a/cli.js
+++ b/cli.js
@@ -156,19 +156,16 @@ program
     .action(start_bilrost_if_not_running(am_actions.forget_workspaces_in_favorite));
 
 program
-    .command('create-workspace <relative_path>')
+    .command('create-workspace <relative_path> <organization> <repository> <branch>')
     .description('Create a workspace')
-    .option('-o, --organization <organization>', 'organization name')
-    .option('-p, --project-name <project_name>', 'project name')
     .option('-d, --description <description>', 'description')
-    .option('-b, --branch <branch>', 'branch')
-    .action(start_bilrost_if_not_running((workspace_relative_path, options) => {
+    .action(start_bilrost_if_not_running((workspace_relative_path, organization, repository, branch, options) => {
         const input = {
             path: Path.join(program.pwd, workspace_relative_path ? workspace_relative_path : ''),
-            organization: options.organization,
-            project_name: options.projectName,
+            organization: organization,
+            project_name: repository,
+            branch: branch,
             description: options.description,
-            branch: options.branch,
             from_repo: true
         };
         return am_actions.create_workspace(input);
@@ -177,12 +174,12 @@ program
         console.log();
         console.log('  Additional information:');
         console.log();
-        console.log('  Target directory given from <absolute_path> must be empty');
+        console.log('  Target directory given from <relative_path> will be created.');
         console.log('  All options are required to be passed');
         console.log();
         console.log('  Example:');
         console.log();
-        console.log('  bilrost create-workspace foo C:\\path\\to\\workspace -o organization_name -p project_name -b master -d "first workspace"');
+        console.log('  bilrost create-workspace folder_name organization_name project_name -master');
     });
 
 program
@@ -211,6 +208,7 @@ program
 
 program
     .command('delete-workspace <relative_path>')
+    .alias('remove-workspace')
     .description('Delete a workspace')
     .option('-i, --identifier <identifier>', 'workspace identifier')
     .action(start_bilrost_if_not_running((workspace_relative_path, options) => {

--- a/use_case_s3_1.bat
+++ b/use_case_s3_1.bat
@@ -7,7 +7,7 @@ set WORKSPACE_PATH=%DIR_PATH%\use_case_s3_1_workspace
 set RESOURCE_PATH=%WORKSPACE_PATH%\alice_resource.txt
 
 echo "Alice creates a workspace"
-call bilrost create-workspace use_case_s3_1_workspace -o fl4re -p open_bilrost_test_project -b production_repo -d "Alice workspace" -B
+call bilrost create-workspace use_case_s3_1_workspace fl4re open_bilrost_test_project production_repo -d "Alice workspace" -B
 
 echo "Alice goes to the new directory"
 cd %WORKSPACE_PATH%

--- a/use_case_s3_1.sh
+++ b/use_case_s3_1.sh
@@ -9,7 +9,7 @@ RESOURCE_PATH="$WORKSPACE_PATH/alice_resource.txt"
 echo $FILE_URL
 
 echo "Alice creates a workspace"
-bilrost create-workspace use_case_s3_1_workspace -o fl4re -p open_bilrost_test_project -b production_repo -d "Alice workspace" -B
+bilrost create-workspace use_case_s3_1_workspace fl4re open_bilrost_test_project production_repo -d "Alice workspace" -B
 
 echo "Alice goes to the new directory"
 cd $WORKSPACE_PATH


### PR DESCRIPTION
`organization`, `project_name` and `branch` arguments are now required from `create-workspace` command.
`project_name` is renamed to `repository`. Updated tests and docs.