### PR TITLE
Input name when bookmarking a workspace

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -28,7 +28,7 @@ const are_you_sure = [
     {
         type: 'input',
         name: 'are_you_sure',
-        message: 'This will remove all resources along subscription/stage lists.\n Are you sure this is what you want?\n input y/n to answer'
+        message: 'This will remove resources and subscription/stage lists.\n Are you sure this is what you want?\n input y/n to answer'
     }
 ];
 
@@ -64,7 +64,6 @@ const find_workspace_url = (pwd = program.pwd) => {
     try {
         return workspace_finder(pwd);
     } catch(err) {
-        logger.spawn_error(err.toString());
         throw err;
     }
 };
@@ -124,34 +123,52 @@ program.command(' -- ');
 
 program
     .command('list-workspaces')
+    .alias('list-workspace')
     .description('List workspaces available in the favorite list')
     .option('-i, --identifier <identifier>', 'workspace identifier')
     .option('-v, --verbose', 'verbose to display asset content')
-    .action(start_bilrost_if_not_running(options => cb_actions.list_workspace(options.identifier, options.verbose)));
+    .action(start_bilrost_if_not_running(options => cb_actions.list_workspace(options.identifier, options.verbose)))
+    .on('--help', () => {
+        console.log();
+        console.log('  Additional information:');
+        console.log();
+
+        console.log('  Only one workspace is listed when using identifier option');
+    });
 
 program
-    .command('add-workspace [relative_path]')
-    .description('Add workspace to the favorite list')
-    .action(start_bilrost_if_not_running(workspace_relative_path => {
+    .command('add-workspace <identifier> [relative_path]')
+    .alias('bookmark')
+    .description('Add workspace to the favorite list with an associated name identifier')
+    .action(start_bilrost_if_not_running((name, workspace_relative_path) => {
         const workspace_absolute_path = Path.join(program.pwd, workspace_relative_path ? workspace_relative_path : '');
-        am_actions.add_workspace_to_favorite(workspace_absolute_path);
-    }));
+        am_actions.add_workspace_to_favorite(name, workspace_absolute_path);
+    }))
+    .on('--help', () => {
+        console.log();
+        console.log('  Additional information:');
+        console.log();
+
+        console.log('  Input identifier can be then used as an argument to apply to commands against associated workspace.');
+    });
 
 program
     .command('forget-workspace <identifier>')
-    .description('Forget a project')
+    .alias('unbookmark')
+    .description('Forget a project from favorite list')
     .action(start_bilrost_if_not_running(am_actions.forget_workspace_in_favorite))
     .on('--help', () => {
         console.log();
         console.log('  Additional information:');
         console.log();
 
-        console.log('  Given identifier can be a workspace name or file uri');
-        console.log('  Run "bilrost list-workspaces" to get these identifiers');
+        console.log('  Given identifier can be a workspace name or file uri.');
+        console.log('  Run "bilrost list-workspaces" to get these identifiers.');
     });
 
 program
     .command('forget-workspaces')
+    .alias('unbookmark-all')
     .description('Forget all workspaces')
     .action(start_bilrost_if_not_running(am_actions.forget_workspaces_in_favorite));
 
@@ -203,7 +220,7 @@ program
     .on('--help', () => {
         console.log();
         console.log('  WARNING');
-        console.log('  You will LOSE your data. All resources will be removed along subscription and stage lists');
+        console.log('  You will LOSE some data. All resources, subscription and stage lists are removed.');
     });
 
 program

--- a/controller/am.js
+++ b/controller/am.js
@@ -17,7 +17,7 @@ const am_model = require('../model/am')(am_config);
 
 const update_asset_usecase = require('../usecases/update_asset');
 
-const add_workspace_to_favorite = path => am_model.add_workspace_to_favorite(file_uri(path))
+const add_workspace_to_favorite = (name, path) => am_model.add_workspace_to_favorite(name, file_uri(path))
     .then(log.spawn_success)
     .catch(log.spawn_error);
 

--- a/model/am.js
+++ b/model/am.js
@@ -8,16 +8,19 @@ module.exports = config => {
 
     const req = require('../util/req')(config.url);
 
-    const add_workspace_to_favorite = uri => req(
+    const add_workspace_to_favorite = (name, file_uri) => req(
         'post',
         '/assetmanager/workspaces/favorites',
         {
-            body: { file_uri: uri }
+            body: {
+                file_uri,
+                name
+            }
         }
     ).then(body => {
-        if (body && body.name) {
+        if (body) {
             return {
-                message: body.name + ' successfully added',
+                message: `${name} workspace successfully bookmarked`,
                 body: body
             };
         } else {

--- a/test/am.js
+++ b/test/am.js
@@ -19,7 +19,7 @@ describe('Am model', function () {
             .then(output => {
                 should.deepEqual({
                     body: body,
-                    message: 'test successfully added'
+                    message: 'test workspace successfully bookmarked'
                 }, output);
                 stub.restore_request('post');
                 done();

--- a/util/workspace_finder.js
+++ b/util/workspace_finder.js
@@ -5,11 +5,12 @@
 'use strict';
 
 const walkback = require('walk-back');
-//const fs = require('fs-extra');
+const fs = require('fs-extra');
 const _path = require('path');
 const file_uri = require('./file_uri');
 
 module.exports = base_path => {
+    fs.statSync(base_path);
     const internal_path = walkback(base_path, '.bilrost');
     if (internal_path) {
         const workspace_path = _path.resolve(internal_path, '..');


### PR DESCRIPTION
- `add-workspace` takes now a name as argument to bookmark with workspace location.
- Better help and added aliases for workspace operations.