### PR TITLE
No more url per namespace when listing assets

### DIFF
--- a/controller/am.js
+++ b/controller/am.js
@@ -71,7 +71,7 @@ const list_asset = (identifier, reference, verbose) => am_model.list_asset(ident
             if (!verbose) {
                 response.body = {
                     assets: response.body.items.map(item => item.meta.ref),
-                    namespaces: response.body.namespaces.map(item => item.ref)
+                    namespaces: response.body.namespaces
                 };
             }
         }


### PR DESCRIPTION
`GET /assetmanager/workspaces/:identifier/assets` API does not return a forward url per namespace anymore.